### PR TITLE
Change getIssues handler

### DIFF
--- a/api/migrations/20200601170120-risk_value_to_lowercase.js
+++ b/api/migrations/20200601170120-risk_value_to_lowercase.js
@@ -1,0 +1,10 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const uuid = require('uuid');
+
+module.exports = {
+  async up(db, client) {
+    await db
+      .collection('issues')
+      .updateMany({}, [{ $set: { risk: { $toLower: '$risk' } } }]);
+  },
+};

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1119,6 +1119,12 @@
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/mongodb": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.5.2.tgz",
@@ -7098,6 +7104,12 @@
         }
       }
     },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
     "merge2": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
@@ -7393,6 +7405,12 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
+    },
+    "mri": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.5.tgz",
+      "integrity": "sha512-d2RKzMD4JNyHMbnbWnznPaa8vbdlq/4pNZ3IgdaGrVbBhebBsGUUE/6qorTMYNS6TwuH3ilfOlD2bf4Igh8CKg==",
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
@@ -8424,6 +8442,181 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
+    },
+    "pretty-quick": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-2.0.1.tgz",
+      "integrity": "sha512-y7bJt77XadjUr+P1uKqZxFWLddvj3SKY6EU4BuQtMxmmEFSMpbN132pUWdSG1g1mtUfO0noBvn7wBf0BVeomHg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "execa": "^2.1.0",
+        "find-up": "^4.1.0",
+        "ignore": "^5.1.4",
+        "mri": "^1.1.4",
+        "multimatch": "^4.0.0"
+      },
+      "dependencies": {
+        "array-differ": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+          "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
+          "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^3.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "multimatch": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+          "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "array-differ": "^3.0.0",
+            "array-union": "^2.1.0",
+            "arrify": "^2.0.1",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "npm-run-path": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
+          "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "process": {
       "version": "0.11.10",
@@ -9784,6 +9977,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-json-comments": {

--- a/api/package.json
+++ b/api/package.json
@@ -80,6 +80,7 @@
     "eslint-plugin-import": "^2.20.1",
     "nyc": "^15.0.0",
     "prettier": "^1.19.1",
+    "pretty-quick": "^2.0.1",
     "source-map-support": "^0.5.16",
     "ts-loader": "^6.2.1",
     "ts-node": "^8.8.0",

--- a/api/src/issues/dto/issues.dto.ts
+++ b/api/src/issues/dto/issues.dto.ts
@@ -1,19 +1,57 @@
 import {
-  IsEmail,
   IsNotEmpty,
   IsString,
-  MinLength,
   IsArray,
   ArrayNotEmpty,
   IsObject,
+  IsUUID,
+  IsOptional,
+  IsIn,
 } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class GetIssuesQueryDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'The slug of a unit you want to get issues for.',
+  })
   @IsString()
   @IsNotEmpty()
   readonly unit: string;
+
+  @ApiPropertyOptional({
+    type: Boolean,
+    description: 'Filter by issue status.',
+  })
+  @IsString()
+  @IsIn(['true', 'false'])
+  @IsOptional()
+  readonly closed?: string;
+
+  @ApiPropertyOptional({
+    type: Boolean,
+    description: 'Filter by ticket.',
+  })
+  @IsString()
+  @IsIn(['true', 'false'])
+  @IsOptional()
+  readonly ticket?: string;
+
+  @ApiPropertyOptional({
+    description: 'Filter by risks. Provide a comma-separated list of risks.',
+  })
+  @IsOptional()
+  @IsString()
+  readonly risks?: string;
+
+  @ApiPropertyOptional({
+    type: Boolean,
+    description: 'Include addtional fields, such as comments and template.',
+    default: 'true',
+  })
+  @IsString()
+  @IsIn(['true', 'false'])
+  @IsOptional()
+  readonly verbose?: string;
 }
 
 export class UpdateIssuesBodyDto {
@@ -29,7 +67,7 @@ export class UpdateIssuesBodyDto {
 
 export class IdParamDto {
   @ApiProperty()
-  @IsString()
+  @IsUUID('4')
   @IsNotEmpty()
   readonly id: string;
 }

--- a/api/src/issues/issues.controller.ts
+++ b/api/src/issues/issues.controller.ts
@@ -1,6 +1,19 @@
-import { Controller, Get, Query, Post, Body, Patch, Param, UseGuards } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Query,
+  Post,
+  Body,
+  Patch,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
 import { IssuesService } from './issues.service';
-import { GetIssuesQueryDto, UpdateIssuesBodyDto, CreateTicketBodyDto, IdParamDto, SaveCommentBodyDto } from './dto/issues.dto';
+import {
+  GetIssuesQueryDto,
+  UpdateIssuesBodyDto,
+  SaveCommentBodyDto,
+} from './dto/issues.dto';
 import { GenericAuthGuard } from 'src/auth/generic-auth.guard';
 import { ApiTags, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
 
@@ -14,21 +27,21 @@ export class IssuesController {
 
   @Get()
   getIssues(@Query() query: GetIssuesQueryDto) {
-    return this.issuesService.get(query.unit);
+    return this.issuesService.get(query);
   }
 
   @Patch()
   updateIssues(@Body() body: UpdateIssuesBodyDto) {
-    return this.issuesService.updateMany(body.ids, body.change)
+    return this.issuesService.updateMany(body.ids, body.change);
   }
 
   @Post(':id/ticket')
   createTicket(@Param('id') id: string, @Body() body: any) {
-    return this.issuesService.createJiraTicket(id, body)
+    return this.issuesService.createJiraTicket(id, body);
   }
 
   @Post(':id/comment')
   saveComment(@Param('id') id: string, @Body() comment: SaveCommentBodyDto) {
-    return this.issuesService.saveComment(id, comment)
+    return this.issuesService.saveComment(id, comment);
   }
 }

--- a/api/src/issues/issues.service.ts
+++ b/api/src/issues/issues.service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import {
   Injectable,
   NotFoundException,
@@ -10,8 +11,9 @@ import { Issue } from './interfaces/issue.interface';
 import { Unit } from 'src/units/interfaces/unit.interface';
 import { Ticket } from './interfaces/ticket.interface';
 import { Comment } from './interfaces/comment.interface';
-import { SaveCommentBodyDto } from './dto/issues.dto';
+import { SaveCommentBodyDto, GetIssuesQueryDto } from './dto/issues.dto';
 import { JiraService } from 'src/plugins/jira/jira.service';
+import { matchPattern } from 'src/utils/converter';
 
 @Injectable()
 export class IssuesService {
@@ -23,26 +25,72 @@ export class IssuesService {
     private jiraService: JiraService
   ) {}
 
-  async get(unitSlug: string) {
-    const unit = await this.unitModel.findOne({ slug: unitSlug });
+  async get(params: GetIssuesQueryDto) {
+    const unit = await this.unitModel.findOne({ slug: params.unit });
+    const options: any = {};
 
     if (!unit) {
       throw new NotFoundException();
+    } else {
+      options.unit = unit._id;
     }
 
-    const issues = await this.issueModel
-      .find({ unit: unit._id })
-      .populate('template', [
-        'title_pattern',
-        'body_fields',
-        'subtitle_pattern',
-        'name',
-      ])
-      .populate('ticket')
-      .populate({
-        path: 'comments',
-        populate: { path: 'author', select: 'username image' },
-      });
+    if (params.closed) {
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      options.is_closed = params.closed === 'true' ? true : false;
+    }
+
+    if (params.ticket) {
+      // eslint-disable-next-line @typescript-eslint/camelcase
+      options.ticket = { $exists: params.ticket === 'true' ? true : false };
+    }
+
+    if (params.risks) {
+      options.risk = { $in: params.risks.split(',') };
+    }
+
+    let issues: any = [];
+
+    if (params.verbose && params.verbose === 'false') {
+      const rawIssues = await this.issueModel
+        .find(options)
+        .populate('template', ['title_pattern', 'subtitle_pattern'])
+        .populate('ticket');
+
+      for (const issue of rawIssues) {
+        issues.push({
+          _id: issue._id,
+          is_closed: issue.is_closed,
+          is_fp: issue.is_fp,
+          is_risk_accepted: issue.is_risk_accepted,
+          title: matchPattern(
+            JSON.parse(issue.fields),
+            issue.template.title_pattern
+          ),
+          subtitle: matchPattern(
+            JSON.parse(issue.fields),
+            issue.template.subtitle_pattern
+          ),
+          risk: issue.risk,
+          created_at: issue.created_at,
+          ticket: issue.ticket,
+        });
+      }
+    } else {
+      issues = await this.issueModel
+        .find(options)
+        .populate('template', [
+          'title_pattern',
+          'body_fields',
+          'subtitle_pattern',
+          'name',
+        ])
+        .populate('ticket')
+        .populate({
+          path: 'comments',
+          populate: { path: 'author', select: 'username image' },
+        });
+    }
 
     return issues;
   }

--- a/api/src/issues/schemas/issue.schema.ts
+++ b/api/src/issues/schemas/issue.schema.ts
@@ -12,8 +12,8 @@ export const IssueSchema = new Schema(
     dup_score: Number,
     risk: {
       type: String,
-      default: 'Medium',
-      enum: ['Low', 'Info', 'Medium', 'High', 'Critical'],
+      default: 'medium',
+      enum: ['low', 'info', 'medium', 'high', 'critical'],
     },
     template: { type: String, ref: 'Template' },
     report: { type: String, ref: 'Report' },
@@ -22,5 +22,5 @@ export const IssueSchema = new Schema(
     tags: [{ type: String }],
     comments: [{ type: String, ref: 'Comment' }],
   },
-  { timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' } },
+  { timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' } }
 );

--- a/api/src/units/units.controller.ts
+++ b/api/src/units/units.controller.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { UnitsService } from './units.service';
 import { GenericAuthGuard } from 'src/auth/generic-auth.guard';
-import { GetUnitsDto, UnitDto, DeleteUnitDto } from './dto/units.dto';
+import { GetUnitsDto, UnitDto } from './dto/units.dto';
 import { ApiTags, ApiBearerAuth, ApiSecurity } from '@nestjs/swagger';
 
 @ApiBearerAuth()
@@ -28,11 +28,11 @@ export class UnitsController {
 
   @Post()
   createUnit(@Body() unit: UnitDto) {
-    return this.unitsService.create(unit)
+    return this.unitsService.create(unit);
   }
 
   @Delete(':id')
-  deleteProject(@Param('id') id: string) {
+  deleteUnit(@Param('id') id: string) {
     return this.unitsService.delete(id);
   }
 }

--- a/api/src/utils/converter.ts
+++ b/api/src/utils/converter.ts
@@ -1,4 +1,5 @@
 import { xml2json } from 'xml-js';
+import { get } from 'lodash';
 
 const removeAttribute = (value, parentElement) => {
   try {
@@ -8,6 +9,22 @@ const removeAttribute = (value, parentElement) => {
   } catch (e) {
     console.log(e);
   }
+};
+
+export const matchPattern = (fields, pattern) => {
+  let result = pattern;
+  const matches = pattern
+    // eslint-disable-next-line no-useless-escape
+    .match(/[a-zA-Z0-9\_\.\[\]]+/gm);
+
+  for (let match of matches) {
+    if (match.startsWith('[') && match.endsWith(']')) {
+      match = match.replace(/^\[/, '').replace(/]$/, '');
+    }
+    result = result.replace(match, get(fields, match));
+  }
+
+  return result;
 };
 
 export function xmlToJson(data) {
@@ -20,4 +37,4 @@ export function xmlToJson(data) {
       cdataFn: removeAttribute,
     })
   );
-};
+}

--- a/web/src/components/IssueFilter.vue
+++ b/web/src/components/IssueFilter.vue
@@ -14,17 +14,6 @@
         </v-col>
         <v-col>
           <v-select
-            v-model="risk_level"
-            :items="severities"
-            prepend-icon="fa-bug"
-            label="Risk"
-            clearable
-            dense
-            @input="$emit('risk_level', risk_level)"
-          />
-        </v-col>
-        <v-col>
-          <v-select
             v-model="closed_status"
             :items="['Yes', 'No']"
             label="Resolved"
@@ -72,6 +61,30 @@
       </v-row>
       <v-row>
         <v-col>
+          <v-select
+            v-model="risk_level"
+            :items="severities"
+            prepend-icon="fa-bug"
+            label="Risk"
+            clearable
+            multiple
+            chips
+            dense
+            @input="$emit('risk_level', risk_level)"
+          >
+            <template v-slot:selection="data">
+              <v-chip
+                :input-value="data.selected"
+                close
+                class="chip--select-multi"
+                @click:close="remove(risk_level, data.item)"
+              >
+                {{ data.item }}
+              </v-chip>
+            </template>
+          </v-select>
+        </v-col>
+        <v-col>
           <v-autocomplete
             v-model="templates"
             :items="templatesNames"
@@ -88,7 +101,7 @@
                 :input-value="data.selected"
                 close
                 class="chip--select-multi"
-                @click:close="remove(data.item)"
+                @click:close="remove(templates, data.item)"
               >
                 {{ data.item }}
               </v-chip>
@@ -137,7 +150,7 @@ export default {
       closed_status: 'No',
       startDate: '',
       endDate: '',
-      risk_level: '',
+      risk_level: [],
       model: null,
       menu2: false,
       menu3: false,
@@ -168,9 +181,9 @@ export default {
     this.$store.dispatch(TEMPLATES_FETCH);
   },
   methods: {
-    remove(item) {
-      const index = this.templates.indexOf(item);
-      if (index >= 0) this.templates.splice(index, 1);
+    remove(array, item) {
+      const index = array.indexOf(item);
+      if (index >= 0) array.splice(index, 1);
     },
   },
 };

--- a/web/src/views/Issues.vue
+++ b/web/src/views/Issues.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container>
-    <v-row>
+    <v-row justify="center" align="center">
       <issue-filter
         @resolution="resolutionStatus = $event"
         @risk_level="risk = $event"
@@ -12,7 +12,7 @@
       />
     </v-row>
     <v-row justify="center" align="center">
-      <v-col cols="12">
+      <v-col cols="10">
         <v-skeleton-loader
           :loading="loading"
           transition="scale-transition"
@@ -47,7 +47,7 @@ export default {
       templates: [],
       timeback: '',
       loading: true,
-      risk: '',
+      risk: [],
     };
   },
   computed: {
@@ -81,8 +81,9 @@ export default {
           ? issuesToDisplay.filter((i) => i.is_closed === this.closed)
           : issuesToDisplay;
 
-      issuesToDisplay =
-        this.risk || '' ? issuesToDisplay.filter((i) => i.risk === this.risk) : issuesToDisplay;
+      issuesToDisplay = this.risk.length
+        ? issuesToDisplay.filter((i) => this.risk.includes(i.risk))
+        : issuesToDisplay;
 
       issuesToDisplay =
         this.ticket !== ''


### PR DESCRIPTION
Make it possible to query issues via API and get a simple representation of them.

Request for 
```
http http://127.0.0.1:3000/api/issues?unit=123123-nff&closed=false&risks=high,low,info&verbose=false "apikey: xxxxx"
``` 
will return a compact representation:

```
[
    {
        "_id": "558d90ad-d8a7-4b7a-8e92-3d214c15d0fa",
        "created_at": "2020-05-14T09:27:22.920Z",
        "is_closed": false,
        "is_fp": false,
        "is_risk_accepted": false,
        "risk": "low",
        "subtitle": "Password: 'MasterLoginPassword'",
        "title": "Generic string with secret expression"
    }
]
```