### PR TITLE
add in project issues view

### DIFF
--- a/web/src/components/dialogs/IssueDetailsDialog.vue
+++ b/web/src/components/dialogs/IssueDetailsDialog.vue
@@ -361,7 +361,7 @@ export default defineComponent({
     });
 
     const projectName = computed(() => store.state.system.projectName);
-    const unitName = computed(() => store.state.system.unitName);
+    const unitName = props.issue.unit as string;
     const items = computed(() => {
       return [
         {
@@ -373,13 +373,13 @@ export default defineComponent({
           },
         },
         {
-          text: unitName.value.replace(projectName.value + '.', ''),
+          text: unitName.replace(projectName.value + '.', ''),
           disabled: false,
           to: {
-            name: 'Units',
+            name: 'Issues',
             params: {
               projectName: projectName.value,
-              unitName: unitName.value,
+              unitName: unitName,
             },
           },
         },

--- a/web/src/router.ts
+++ b/web/src/router.ts
@@ -88,6 +88,14 @@ export const router = new Router({
           meta: { title: 'Purify | Overview' },
         },
         {
+          path: 'issues',
+          name: 'ProjectIssues',
+          components: {
+            default: () => import('@/views/ProjectIssues.vue'),
+          },
+          meta: { title: 'Purify | Project Issues' },
+        },
+        {
           path: 'units/overview',
           name: 'Units',
           meta: { title: 'Purify | Units' },

--- a/web/src/views/ProjectIssues.vue
+++ b/web/src/views/ProjectIssues.vue
@@ -1,0 +1,242 @@
+<template>
+  <v-container>
+    <v-skeleton-loader
+      :loading="loading"
+      transition="slide-y-transition"
+      type="table-thead"
+    >
+      <v-row justify="center" align="center">
+        <issue-filter
+          :keywords="keywordsList"
+          :risk-filter-items="valuesForFilter('risk', ['low', 'info', 'medium', 'high', 'critical'])"
+          :status-filter-items="valuesForFilter('status', ['open', 'closed'])"
+          :resolution-filter-items="valuesForFilter('resolution', ['false positive', 'accepted risk', 'resolved', 'none'])"
+          :template-filter-items="templatesValuesForFilter()"
+          :ticket-filter-items="ticketValuesForFilter()"
+          @search_term="searchTerm = $event"
+          @filter_update="filterOptions = $event"
+        />
+      </v-row>
+    </v-skeleton-loader>
+    <v-skeleton-loader
+      class="my-3"
+      :loading="loading"
+      transition="slide-y-transition"
+      type="list"
+      :types="{'list': 'table-heading, list-item-avatar-three-line@5'}"
+    >
+      <issues-list :raw-items="filtredIssues" />
+    </v-skeleton-loader>
+  </v-container>
+</template>
+<script lang="ts">
+/* eslint-disable @typescript-eslint/no-use-before-define */
+import {
+  defineComponent,
+  ref,
+  Ref,
+  onMounted,
+  ComputedRef,
+  computed,
+  watch,
+} from '@vue/composition-api';
+import store from '@/store';
+import IssuesList from '@/components/IssuesList.vue';
+import { compareDesc, sub } from 'date-fns';
+import IssueFilter from '@/components/IssueFilter.vue';
+import { ISSUES_FETCH, TEMPLATES_FETCH } from '@/store/actions';
+import {
+  Issue,
+  FilterValue,
+  FilterOption,
+  TemplateWithStats,
+} from '@/store/types';
+import { SET_ISSUES_QUERY } from '@/store/mutations';
+
+export default defineComponent({
+  name: 'Issues',
+
+  components: {
+    IssuesList,
+    IssueFilter,
+  },
+
+  setup(props, context) {
+    const loading = ref(true);
+    const {
+      filterOptions,
+      searchTerm,
+      filtredIssues,
+      valuesForFilter,
+      templatesValuesForFilter,
+      ticketValuesForFilter,
+    } = useFiltres();
+
+    const keywordsList = computed(() => {
+      let result: string[] = [];
+
+      filtredIssues.value.forEach((issue) => {
+        const list = Object.values(issue.fields)
+          .toString()
+          .match(/[a-zA-Z0-9\._-]{3,}/gm);
+        result = result.concat([...new Set(list)]);
+      });
+
+      return [...new Set(result)];
+    });
+    const unitName = computed(() => store.state.system.unitName);
+    const projectName = computed(() => store.state.system.projectName);
+
+    const queryParams = computed(() => {
+      return filterOptions.value.reduce(function (r, a) {
+        // @ts-ignore
+        r[a.name] = r[a.name] || '';
+        // @ts-ignore
+        if (r[a.name] === '') {
+          // @ts-ignore
+          r[a.name] = a.value;
+        } else {
+          // @ts-ignore
+          const ops = r[a.name].split(',');
+          ops.push(a.value);
+          // @ts-ignore
+          r[a.name] = ops.toString();
+        }
+        return r;
+      }, {});
+    });
+
+    onMounted(() => {
+      store.dispatch(TEMPLATES_FETCH).catch(() => {});
+      store.commit(SET_ISSUES_QUERY, queryParams.value);
+      store
+        .dispatch(ISSUES_FETCH, {
+          projectName: projectName.value,
+          ...queryParams.value,
+        })
+        .then(() => {
+          loading.value = false;
+        })
+        .catch(() => {});
+    });
+
+    watch(queryParams, async () => {
+      // if (newValue.value !== oldValue.value) {
+      store.commit(SET_ISSUES_QUERY, queryParams.value);
+      await store
+        .dispatch(ISSUES_FETCH, {
+          unitName: unitName.value,
+          ...queryParams.value,
+        })
+        .catch(() => {});
+      // }
+    });
+
+    return {
+      loading,
+      searchTerm,
+      queryParams,
+      keywordsList,
+      filterOptions,
+      filtredIssues,
+      templatesValuesForFilter,
+      valuesForFilter,
+      ticketValuesForFilter,
+    };
+  },
+});
+
+function useFiltres() {
+  const searchTerm = ref('');
+  const issues: ComputedRef<Issue[]> = computed(() => store.state.issues.items);
+  const templates: ComputedRef<TemplateWithStats[]> = computed(
+    () => store.state.templates.items
+  );
+  const filterOptions: Ref<FilterOption[]> = ref([
+    { name: 'status', value: 'open' },
+  ]);
+  const filtredIssues = computed(() => {
+    let issuesToDisplay = issues.value;
+
+    issuesToDisplay = searchTerm.value
+      ? issues.value.filter((i) =>
+          JSON.stringify(Object.values(i.fields))
+            .toLowerCase()
+            .includes(searchTerm.value.toLowerCase())
+        )
+      : issuesToDisplay;
+
+    return issuesToDisplay;
+  });
+
+  function valuesForFilter(fieldName: string, values: string[]) {
+    const result: FilterValue[] = [];
+
+    values.forEach((value) => {
+      const total = filtredIssues.value.filter(
+        // @ts-ignore
+        (issue) => issue[fieldName] === value
+      ).length;
+      result.push({
+        title: value,
+        total: total,
+        value: (total / filtredIssues.value.length) * 100,
+      });
+    });
+
+    return result.sort((a, b) => b.total - a.total);
+  }
+
+  function ticketValuesForFilter() {
+    const result: FilterValue[] = [];
+
+    const totalTickets = filtredIssues.value.filter((issue) => issue['ticket'])
+      .length;
+    result.push(
+      {
+        title: 'true',
+        total: totalTickets,
+        value: (totalTickets / filtredIssues.value.length) * 100,
+      },
+      {
+        title: 'false',
+        total: filtredIssues.value.length - totalTickets,
+        value:
+          ((filtredIssues.value.length - totalTickets) /
+            filtredIssues.value.length) *
+          100,
+      }
+    );
+
+    return result.sort((a, b) => b.total - a.total);
+  }
+
+  function templatesValuesForFilter() {
+    const result: FilterValue[] = [];
+
+    templates.value
+      .map((template) => template.displayName)
+      .forEach((templateName) => {
+        const total = filtredIssues.value.filter(
+          (issue) => issue.template === templateName
+        ).length;
+        result.push({
+          title: templateName,
+          total: total,
+          value: (total / filtredIssues.value.length) * 100,
+        });
+      });
+
+    return result.sort((a, b) => b.total - a.total);
+  }
+
+  return {
+    filterOptions,
+    searchTerm,
+    filtredIssues,
+    valuesForFilter,
+    templatesValuesForFilter,
+    ticketValuesForFilter,
+  };
+}
+</script>

--- a/web/src/views/ProjectIssues.vue
+++ b/web/src/views/ProjectIssues.vue
@@ -84,7 +84,6 @@ export default defineComponent({
 
       return [...new Set(result)];
     });
-    const unitName = computed(() => store.state.system.unitName);
     const projectName = computed(() => store.state.system.projectName);
 
     const queryParams = computed(() => {
@@ -125,7 +124,7 @@ export default defineComponent({
       store.commit(SET_ISSUES_QUERY, queryParams.value);
       await store
         .dispatch(ISSUES_FETCH, {
-          unitName: unitName.value,
+          projectName: projectName.value,
           ...queryParams.value,
         })
         .catch(() => {});

--- a/web/src/views/ProjectPage.vue
+++ b/web/src/views/ProjectPage.vue
@@ -17,9 +17,9 @@
         <v-fade-transition group hide-on-leave>
           <span
             v-if="unit"
-            key="unitName"
+            key="projectName"
             class="text-h6 font-weight-black mr-3"
-          >{{ unit.displayName }}</span>
+          >{{ project.displayName }}: {{unit.displayName}}</span>
           <span
             v-else
             key="projectName"
@@ -35,6 +35,17 @@
             <v-icon left>
               mdi-poll
             </v-icon>Overview
+          </v-btn>
+          <v-btn
+            key="all-issues"
+            class="mx-2 mb-2"
+            text
+            :to="{ name: 'ProjectIssues' }"
+            color="primary"
+          >
+            <v-icon left>
+              mdi-bug
+            </v-icon>Project Issues
           </v-btn>
           <v-btn
             key="units"


### PR DESCRIPTION
In this PR I've added in a tab for viewing all the issues in a project rather then having to look over each unit individually. I've also changed the project name to be displayed even when in a unit. See the images below for the changes. The "Project Issues" tab is the same as the existing "Issues" tab except that it shows all issues in a project not just one specific unit.

![2021-03-02_12-27](https://user-images.githubusercontent.com/2067021/109684523-3fb43a00-7b78-11eb-8e42-4469fd74d795.png)

![2021-03-02_12-29](https://user-images.githubusercontent.com/2067021/109684527-404cd080-7b78-11eb-8a5e-b96a82c0feda.png)


